### PR TITLE
fix sorting bug

### DIFF
--- a/src/models/lapmodel.cpp
+++ b/src/models/lapmodel.cpp
@@ -56,7 +56,7 @@ QVariant LapModel::data(const QModelIndex& index, int role) const
 
     switch (static_cast<Roles>(role)) {
     case Roles::LapIdRole:
-        return QString::number(index.row() + 1);
+        return index.row() + 1;
     case Roles::RelativeTimeRole:
         return m_laps.at(index.row()).relativeTime();
     case Roles::AbsoluteTimeRole:


### PR DESCRIPTION
When lap table is sorted, sorting numbers as strings caused numbers over 9 to be mis-sorted, in wrong order. 1 and 11 were sorted close.

Numbers should not be converted to strings before sorting.