### PR TITLE
Add trigger on startup option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 *build/
 CMakeLists.txt.user
 *.kdev4
+cmake-build-debug/
+.idea/
+.vscode/

--- a/src/gui/generalsettings.ui
+++ b/src/gui/generalsettings.ui
@@ -144,6 +144,13 @@
          </property>
         </spacer>
        </item>
+       <item>
+        <widget class="QCheckBox" name="kcfg_triggerOnStartup">
+          <property name="text">
+            <string>Trigger on startup</string>
+          </property>
+        </widget>
+       </item>
       </layout>
      </widget>
      <widget class="QWidget" name="tab_2">

--- a/src/gui/kronometer.kcfg
+++ b/src/gui/kronometer.kcfg
@@ -11,6 +11,9 @@
     <kcfgfile name="kronometerrc"/>
 
     <group name="General">
+        <entry name="triggerOnStartup" type="Bool">
+            <default>false</default>
+        </entry>
         <entry name="showHours" type="Bool">
             <default>false</default>
         </entry>

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -100,6 +100,11 @@ MainWindow::MainWindow(SessionModel *sessionModel, QWidget *parent, const Sessio
     m_screensaverInterface = new QDBusInterface(QStringLiteral("org.freedesktop.ScreenSaver"),
                                                 QStringLiteral("/ScreenSaver"),
                                                 QStringLiteral("org.freedesktop.ScreenSaver"));
+        
+    if (m_triggerOnStartup) {
+        m_stopwatch->start();        
+    }
+    
 }
 
 MainWindow::~MainWindow()
@@ -506,6 +511,8 @@ void MainWindow::loadSettings()
 
     auto timeFormat = TimeFormat {KronometerConfig::showHours(), KronometerConfig::showMinutes(), timeFrac};
     auto lapTimeFormat = TimeFormat {KronometerConfig::showLapHours(), KronometerConfig::showLapMinutes(), lapFrac};
+
+    m_triggerOnStartup = KronometerConfig::triggerOnStartup();
 
     m_lapAction->setVisible(KronometerConfig::isLapsRecordingEnabled());
     m_exportAction->setVisible(KronometerConfig::isLapsRecordingEnabled());

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -146,6 +146,7 @@ private slots:
 
 private:
 
+    bool m_triggerOnStartup;
     Stopwatch *m_stopwatch;
     TimeDisplay *m_stopwatchDisplay;
     QTableView *m_lapView;


### PR DESCRIPTION
Bug 423034 - [Feature Request] Option to start timer immediately

Added a setting within Kronometer to automatically start the timer on launch.